### PR TITLE
disconnect from APRS server if connection hangs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-aprs"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Dave Lewis <dave@dllewis.org>"]
 edition = "2018"
 description = "APRS Library to interact with APRS-IS servers"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,15 @@
 use aprs_parser::EncodeError;
 use std::{io, string};
 use thiserror::Error;
+use tokio::time::error::Elapsed;
 
 #[derive(Error, Debug)]
 pub enum ISReadError {
     #[error(transparent)]
     IoError(#[from] io::Error),
+
+    #[error("TCP read timeout - connection died")]
+    TcpReadTimeout(#[from] Elapsed),
 
     #[error("Server command was not valid UTF8")]
     ServerCommandInvalidUtf8(#[from] string::FromUtf8Error),


### PR DESCRIPTION
Previously a hanging TCP connection (i.e. on an intermittent network) would cause the APRS client to hang indefinitely. Now, it'll disconnect after a minute of hearing nothing. The APRS-IS servers send heartbeats regularly so this shouldn't cause any false disconnects